### PR TITLE
Fix for Google APIs restricted by http referrer

### DIFF
--- a/admin/includes/fonts_face.php
+++ b/admin/includes/fonts_face.php
@@ -430,7 +430,8 @@ class People_Contact_Fonts_Face extends People_Contact_Admin_UI
 				$respone_api = wp_remote_get( "https://www.googleapis.com/webfonts/v1/webfonts?sort=alpha&key=" . trim( $this->google_api_key ),
 					array(
 						'sslverify' => false,
-						'timeout'   => 45
+						'timeout'   => 45,
+						'headers' => array( 'referer' => get_site_url() ) 
 					)
 				);
 


### PR DESCRIPTION
Added referer to get request for valid googleapis response when api key restricted by site url