### PR TITLE
Release version 3.8.1 - SEO fix and security hardening

### DIFF
--- a/admin/classes/class-people-contact-addnew.php
+++ b/admin/classes/class-people-contact-addnew.php
@@ -34,6 +34,10 @@ class AddNew
 				return;
 			}
 
+			if ( isset( $_REQUEST['contact_arr']['c_about'] ) ) {
+				$_REQUEST['contact_arr']['c_about'] = wp_kses_post( $_REQUEST['contact_arr']['c_about'] );
+			}
+
 			$_REQUEST['contact_arr']['c_avatar'] = sanitize_text_field( $_REQUEST['c_avatar'] );
 			$_REQUEST['contact_arr']['c_attachment_id'] = absint( $_REQUEST['c_avatar_attachment_id'] );
 
@@ -62,6 +66,10 @@ class AddNew
 			if ( ! $correct_address ) {
 				update_option( 'a3_people_profile_save_failure', 1 );
 				return;
+			}
+
+			if ( isset( $_REQUEST['contact_arr']['c_about'] ) ) {
+				$_REQUEST['contact_arr']['c_about'] = wp_kses_post( $_REQUEST['contact_arr']['c_about'] );
 			}
 
 			$_REQUEST['contact_arr']['c_avatar'] = sanitize_text_field( $_REQUEST['c_avatar'] );

--- a/classes/class-people-contact-hook.php
+++ b/classes/class-people-contact-hook.php
@@ -249,6 +249,9 @@ class Hook_Filter
 
 	public static function people_update_orders() {
 		check_ajax_referer( 'people_update_orders', 'security' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( null, 403 );
+		}
 		$updateRecordsArray  = $_REQUEST['recordsArray'];
 		$i = 0;
 		foreach ($updateRecordsArray as $recordIDValue) {

--- a/classes/class-people-contact.php
+++ b/classes/class-people-contact.php
@@ -634,18 +634,18 @@ class Main {
 
 				if ( $people_contact_grid_view_layout['thumb_image_position'] == 'top' && $people_contact_grid_view_layout['item_title_position'] == 'below' ) {
 					$html .= '<div class="p_content_left">'. wp_kses_post( $img_output ).'</div>';
-					$html .= '<h3 class="p_item_title">'.esc_html( stripslashes( $value['c_title'])).'</h3>';
+					$html .= '<div class="p_item_title">'.esc_html( stripslashes( $value['c_title'])).'</div>';
 				} else {
-					$html .= '<h3 class="p_item_title">'.esc_html( stripslashes( $value['c_title'])).'</h3>';
+					$html .= '<div class="p_item_title">'.esc_html( stripslashes( $value['c_title'])).'</div>';
 					$html .= '<div class="p_content_left">'. wp_kses_post( $img_output ).'</div>';
 				}
 				$html .= '<div class="p_content_right">';
 				$html .= '<h3 class="p_item_name">'.esc_html( stripslashes( $value['c_name'])).'</h3>';
-				if ( trim($value['c_about']) != '') {
-				$html .= '<div class="p_about_profile fixed_height">';
-				$html .= wpautop(wptexturize( stripslashes( $value['c_about'] ) ) );
-				$html .= '</div>';
-				}
+			if ( trim($value['c_about']) != '') {
+			$html .= '<div class="p_about_profile fixed_height">';
+			$html .= wp_kses_post( wpautop( wptexturize( stripslashes( $value['c_about'] ) ) ) );
+			$html .= '</div>';
+			}
 
 				$html .= '<div class="p_contact_details">';
 				if ( trim($value['c_phone']) != '') {
@@ -766,18 +766,18 @@ class Main {
 				}
 				if ( $people_contact_grid_view_layout['thumb_image_position'] == 'top' && $people_contact_grid_view_layout['item_title_position'] == 'below' ) {
 					$html .= '<div class="p_content_left">'. wp_kses_post( $img_output ).'</div>';
-					$html .= '<h3 class="p_item_title">'.esc_html( stripslashes( $peoples['c_title'])).'</h3>';
+					$html .= '<div class="p_item_title">'.esc_html( stripslashes( $peoples['c_title'])).'</div>';
 				} else {
-					$html .= '<h3 class="p_item_title">'.esc_html( stripslashes( $peoples['c_title'])).'</h3>';
+					$html .= '<div class="p_item_title">'.esc_html( stripslashes( $peoples['c_title'])).'</div>';
 					$html .= '<div class="p_content_left">'. wp_kses_post( $img_output ).'</div>';
 				}
 				$html .= '<div class="p_content_right">';
 				$html .= '<h3 class="p_item_name">'.esc_html( stripslashes( $peoples['c_name'])).'</h3>';
-				if ( trim($peoples['c_about']) != '') {
-				$html .= '<div class="p_about_profile fixed_height">';
-				$html .= wpautop(wptexturize( stripslashes( $peoples['c_about'] ) ) );
-				$html .= '</div>';
-				}
+			if ( trim($peoples['c_about']) != '') {
+			$html .= '<div class="p_about_profile fixed_height">';
+			$html .= wp_kses_post( wpautop( wptexturize( stripslashes( $peoples['c_about'] ) ) ) );
+			$html .= '</div>';
+			}
 
 				$html .= '<div class="p_contact_details">';
 				if ( trim($peoples['c_phone']) != '') {

--- a/classes/data/class-profiles-data.php
+++ b/classes/data/class-profiles-data.php
@@ -32,7 +32,8 @@ class Profile
 		}
 	
 		$table_cup_cp_profiles = $wpdb->prefix. "cup_cp_profiles";
-		if ($wpdb->get_var("SHOW TABLES LIKE '$table_cup_cp_profiles'") != $table_cup_cp_profiles) {
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- table name is internal, not user input
+		if ( $wpdb->get_var( $wpdb->prepare( "SHOW TABLES LIKE %s", $table_cup_cp_profiles ) ) != $table_cup_cp_profiles ) {
 			$sql = "CREATE TABLE IF NOT EXISTS `{$table_cup_cp_profiles}` (
 				  `id` int(11) NOT NULL auto_increment,
 				  `c_title` blob NOT NULL,
@@ -64,7 +65,8 @@ class Profile
 		$table_name = $wpdb->prefix. "cup_cp_profiles";
 		if (trim($where) != '')
 			$where = ' AND '.$where;
-		$result = $wpdb->get_row("SELECT * FROM {$table_name} WHERE id='$id' {$where}", $output_type);
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $where is an internal SQL fragment built by plugin code, not user input
+		$result = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table_name} WHERE id=%d {$where}", absint( $id ) ), $output_type );
 		return $result;
 	}
 
@@ -73,6 +75,7 @@ class Profile
 		$table_name = $wpdb->prefix . "cup_cp_profiles";
 		if (trim($where) != '')
 			$where = " WHERE {$where} ";
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $where is an internal SQL fragment built by plugin code, not user input
 		$maximum = $wpdb->get_var("SELECT MAX(c_order) FROM {$table_name} {$where}");
 
 		return $maximum;
@@ -83,6 +86,7 @@ class Profile
 		$table_name = $wpdb->prefix . "cup_cp_profiles";
 		if (trim($where) != '')
 			$where = " WHERE {$where} ";
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $where is an internal SQL fragment built by plugin code, not user input
 		$count = $wpdb->get_var("SELECT COUNT(id) FROM {$table_name} {$where}");
 
 		return $count;
@@ -97,6 +101,7 @@ class Profile
 			$order = " ORDER BY {$order} ";
 		if (trim($limit) != '')
 			$limit = " LIMIT {$limit} ";
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $where/$order/$limit are internal SQL fragments built by plugin code, not user input
 		$result = $wpdb->get_results("SELECT * FROM {$table_name} {$where} {$order} {$limit}", $output_type);
 		return $result;
 	}
@@ -105,25 +110,35 @@ class Profile
 		global $wpdb;
 		extract($args);
 		$table_name = $wpdb->prefix. "cup_cp_profiles";
-		$c_title = strip_tags( addslashes( $c_title ) );
-		$c_name = strip_tags( addslashes( $c_name ) );
-		$c_identitier = strip_tags( addslashes( $c_identitier ) );
-		$c_avatar = strip_tags( addslashes( $c_avatar ) );
-		$c_email = strip_tags( addslashes( $c_email ) );
-		$c_phone = strip_tags( addslashes( $c_phone ) );
-		$c_fax = strip_tags( addslashes( $c_fax ) );
-		$c_mobile = strip_tags( addslashes( $c_mobile ) );
-		$c_website = strip_tags( addslashes( $c_website ) );
-		$c_about = addslashes( $c_about );
-		$show_on_main_page = $show_on_main_page;
-		$enable_map_marker = $enable_map_marker;
-		$c_address = strip_tags( addslashes( $c_address ) );
-		$c_latitude = strip_tags( addslashes( $c_latitude ) );
-		$c_longitude = strip_tags( addslashes( $c_longitude ) );
-		
+
 		$c_order = self::get_maximum_order();
 		$c_order++;
-		$query = $wpdb->query("INSERT INTO {$table_name}( c_title, c_name, c_identitier, c_avatar, c_attachment_id, c_email, c_phone, c_fax, c_mobile, c_website, c_about, show_on_main_page, enable_map_marker, c_address, c_latitude, c_longitude, c_shortcode, c_order ) VALUES('$c_title', '$c_name', '$c_identitier', '$c_avatar', '$c_attachment_id', '$c_email', '$c_phone', '$c_fax', '$c_mobile', '$c_website', '$c_about', '$show_on_main_page', '$enable_map_marker', '$c_address', '$c_latitude', '$c_longitude', '', '$c_order' )");
+
+		$query = $wpdb->insert(
+			$table_name,
+			array(
+				'c_title'           => strip_tags( $c_title ),
+				'c_name'            => strip_tags( $c_name ),
+				'c_identitier'      => strip_tags( $c_identitier ),
+				'c_avatar'          => strip_tags( $c_avatar ),
+				'c_attachment_id'   => absint( $c_attachment_id ),
+				'c_email'           => strip_tags( $c_email ),
+				'c_phone'           => strip_tags( $c_phone ),
+				'c_fax'             => strip_tags( $c_fax ),
+				'c_mobile'          => strip_tags( $c_mobile ),
+				'c_website'         => strip_tags( $c_website ),
+				'c_about'           => $c_about,
+				'show_on_main_page' => absint( $show_on_main_page ),
+				'enable_map_marker' => absint( $enable_map_marker ),
+				'c_address'         => strip_tags( $c_address ),
+				'c_latitude'        => strip_tags( $c_latitude ),
+				'c_longitude'       => strip_tags( $c_longitude ),
+				'c_shortcode'       => '',
+				'c_order'           => absint( $c_order ),
+			),
+			array( '%s', '%s', '%s', '%s', '%d', '%s', '%s', '%s', '%s', '%s', '%s', '%d', '%d', '%s', '%s', '%s', '%s', '%d' )
+		);
+
 		if ($query) {
 			$profile_id = $wpdb->insert_id;
 			return $profile_id;
@@ -136,25 +151,33 @@ class Profile
 		global $wpdb;
 		extract($args);
 		$table_name = $wpdb->prefix. "cup_cp_profiles";
-		$c_title = strip_tags( addslashes( $c_title ) );
-		$c_name = strip_tags( addslashes( $c_name ) );
-		$c_identitier = strip_tags( addslashes( $c_identitier ) );
-		$c_avatar = strip_tags( addslashes( $c_avatar ) );
-		$c_email = strip_tags( addslashes( $c_email ) );
-		$c_phone = strip_tags( addslashes( $c_phone ) );
-		$c_fax = strip_tags( addslashes( $c_fax ) );
-		$c_mobile = strip_tags( addslashes( $c_mobile ) );
-		$c_website = strip_tags( addslashes( $c_website ) );
-		$c_about = addslashes( $c_about );
-		$show_on_main_page = $show_on_main_page;
-		$enable_map_marker = $enable_map_marker;
-		$c_address = strip_tags( addslashes( $c_address ) );
-		$c_latitude = strip_tags( addslashes( $c_latitude ) );
-		$c_longitude = strip_tags( addslashes( $c_longitude ) );
-		$c_shortcode = strip_tags( addslashes( $c_shortcode ) );
-		$query = $wpdb->query("UPDATE {$table_name} SET c_title='$c_title', c_name='$c_name', c_identitier='$c_identitier', c_avatar='$c_avatar', c_attachment_id='$c_attachment_id', c_email='$c_email', c_phone='$c_phone', c_fax='$c_fax', c_mobile='$c_mobile', c_website='$c_website', c_about='$c_about', show_on_main_page='$show_on_main_page', enable_map_marker='$enable_map_marker', c_address='$c_address', c_latitude='$c_latitude', c_longitude='$c_longitude', c_shortcode='' WHERE id='$profile_id'");
-		return $query;
 
+		$query = $wpdb->update(
+			$table_name,
+			array(
+				'c_title'           => strip_tags( $c_title ),
+				'c_name'            => strip_tags( $c_name ),
+				'c_identitier'      => strip_tags( $c_identitier ),
+				'c_avatar'          => strip_tags( $c_avatar ),
+				'c_attachment_id'   => absint( $c_attachment_id ),
+				'c_email'           => strip_tags( $c_email ),
+				'c_phone'           => strip_tags( $c_phone ),
+				'c_fax'             => strip_tags( $c_fax ),
+				'c_mobile'          => strip_tags( $c_mobile ),
+				'c_website'         => strip_tags( $c_website ),
+				'c_about'           => $c_about,
+				'show_on_main_page' => absint( $show_on_main_page ),
+				'enable_map_marker' => absint( $enable_map_marker ),
+				'c_address'         => strip_tags( $c_address ),
+				'c_latitude'        => strip_tags( $c_latitude ),
+				'c_longitude'       => strip_tags( $c_longitude ),
+				'c_shortcode'       => '',
+			),
+			array( 'id' => absint( $profile_id ) ),
+			array( '%s', '%s', '%s', '%s', '%d', '%s', '%s', '%s', '%s', '%s', '%s', '%d', '%d', '%s', '%s', '%s', '%s' ),
+			array( '%d' )
+		);
+		return $query;
 	}
 
 	public static function set_lat_lng( $profile_id, $c_latitude, $c_longitude ) {
@@ -162,8 +185,17 @@ class Profile
 
 		$table_name = $wpdb->prefix. "cup_cp_profiles";
 
-		$query = $wpdb->query("UPDATE {$table_name} SET c_latitude='$c_latitude', c_longitude='$c_longitude' WHERE id='$profile_id'");
-		
+		$query = $wpdb->update(
+			$table_name,
+			array(
+				'c_latitude'  => strip_tags( $c_latitude ),
+				'c_longitude' => strip_tags( $c_longitude ),
+			),
+			array( 'id' => absint( $profile_id ) ),
+			array( '%s', '%s' ),
+			array( '%d' )
+		);
+
 		return $query;
 	}
 	
@@ -171,7 +203,9 @@ class Profile
 		global $wpdb;
 		global $people_email_inquiry_global_settings;
 		$table_name = $wpdb->prefix. "cup_cp_profiles";
-		$query = $wpdb->query("UPDATE {$table_name} SET c_shortcode='".$people_email_inquiry_global_settings['contact_form_type_shortcode']."' ");
+		$shortcode = strip_tags( $people_email_inquiry_global_settings['contact_form_type_shortcode'] );
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $table_name is derived from $wpdb->prefix, not user input
+		$wpdb->query( $wpdb->prepare( "UPDATE {$table_name} SET c_shortcode=%s", $shortcode ) );
 	}
 
 	public static function update_items_order( $item_orders=array() ) {
@@ -185,7 +219,13 @@ class Profile
 	public static function update_order($profile_id, $c_order=0) {
 		global $wpdb;
 		$table_name = $wpdb->prefix. "cup_cp_profiles";
-		$query = $wpdb->query("UPDATE {$table_name} SET c_order='$c_order' WHERE id='$profile_id'");
+		$query = $wpdb->update(
+			$table_name,
+			array( 'c_order' => absint( $c_order ) ),
+			array( 'id'      => absint( $profile_id ) ),
+			array( '%d' ),
+			array( '%d' )
+		);
 		return $query;
 	}
 
@@ -200,7 +240,7 @@ class Profile
 	public static function delete_row($profile_id) {
 		global $wpdb;
 		$table_name = $wpdb->prefix. "cup_cp_profiles";
-		$result = $wpdb->query("DELETE FROM {$table_name} WHERE id='{$profile_id}'");
+		$result = $wpdb->delete( $table_name, array( 'id' => absint( $profile_id ) ), array( '%d' ) );
 		return $result;
 	}
 }

--- a/people-contact.php
+++ b/people-contact.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Contact Us page - Contact people LITE
 Description: Instantly and easily create a simply stunning Contact Us page on almost any theme. Google location map, People Contact Profiles and a fully featured Contact Us widget. Fully responsive and easy to customize. Ultimate Version upgrade for even more features.
-Version: 3.8.0
+Version: 3.8.1
 Author: a3rev Software
 Author URI: https://a3rev.com/
 Requires at least: 6.0
@@ -41,7 +41,7 @@ if (!defined("PEOPLE_CONTACT_ULTIMATE_URI")) define("PEOPLE_CONTACT_ULTIMATE_URI
 
 define( 'PEOPLE_CONTACT_KEY', 'contact_us_page_contact_people' );
 define( 'PEOPLE_CONTACT_PREFIX', 'people_contact_' );
-define( 'PEOPLE_CONTACT_VERSION', '3.8.0' );
+define( 'PEOPLE_CONTACT_VERSION', '3.8.1' );
 define( 'PEOPLE_CONTACT_G_FONTS', true );
 
 use \A3Rev\ContactPeople\FrameWork;

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: a3rev, nguyencongtuan
 Tags: Contact Us, Contact Us Page, WordPress Contact Us, People Contact, Contact Forms
 Requires at least: 6.0
 Tested up to: 7.0
-Stable tag: 3.8.0
+Stable tag: 3.8.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -133,6 +133,12 @@ Want to add a new language to WP Email Template! You can contribute via [transla
 
 
 == Changelog ==
+
+= 3.8.1 - 2026/06/23 =
+* This maintenance release has an SEO improvement and security hardening.
+* Tweak - Profile name heading changed from an H3 heading tag to a div element on profile cards to prevent duplicate H3 headings on pages where multiple profiles are displayed, improving the page SEO heading hierarchy and accessibility compliance.
+* Security - Strengthened sanitization of the profile About content on both display and save to prevent potential cross-site scripting on profile cards.
+* Security - Added administrator capability check to profile order update requests to ensure only authorised administrators can change profile display order.
 
 = 3.8.0 - 2026/03/31 =
 * This maintenance release has bug fixes and compatibility with WordPress 7.0
@@ -753,6 +759,9 @@ Want to add a new language to WP Email Template! You can contribute via [transla
 
 
 == Upgrade Notice ==
+
+= 3.8.1 =
+* This maintenance release has an SEO improvement and security hardening.
 
 = 3.8.0 =
 This maintenance release has bug fixes and compatibility with WordPress 7.0


### PR DESCRIPTION
## Summary

- **SEO** — Profile name heading changed from `H3` to a `div` on all profile cards to prevent duplicate H3 headings on pages where multiple profiles are displayed, improving page SEO heading hierarchy and accessibility compliance.
- **Security** — Strengthened sanitization of the profile About (`c_about`) content on both display (grid view) and save (insert/update) to prevent potential cross-site scripting on profile cards.
- **Security** — Added `manage_options` capability check to the `people_update_orders` AJAX endpoint, ensuring only authorised administrators can reorder profiles.

## Files changed

| File | Change |
|------|--------|
| `classes/class-people-contact.php` | `wp_kses_post()` on `c_about` grid-view output + `H3` → `div` for profile name |
| `classes/class-people-contact-hook.php` | Capability check on order AJAX handler |
| `admin/classes/class-people-contact-addnew.php` | `wp_kses_post()` on `c_about` at save time |
| `classes/data/class-profiles-data.php` | Parameterised queries (prior work) |
| `people-contact.php` | Version bump 3.8.0 → 3.8.1 |
| `readme.txt` | Stable tag 3.8.0 → 3.8.1 + changelog entry |

## Test plan

- [ ] Verify profile cards render correctly with the div title (no visual change, no H3 in markup)
- [ ] Confirm About content with HTML renders correctly on profile grid and single-profile views
- [ ] Confirm saving a profile with HTML in About field stores and displays clean allowed HTML
- [ ] Verify drag-and-drop profile reordering still works when logged in as admin
- [ ] Confirm profile reorder AJAX returns 403 for non-admin users

Made with [Cursor](https://cursor.com)