### PR TITLE
Release new version 3.8.2

### DIFF
--- a/classes/class-people-contact.php
+++ b/classes/class-people-contact.php
@@ -640,7 +640,7 @@ class Main {
 					$html .= '<div class="p_content_left">'. wp_kses_post( $img_output ).'</div>';
 				}
 				$html .= '<div class="p_content_right">';
-				$html .= '<h3 class="p_item_name">'.esc_html( stripslashes( $value['c_name'])).'</h3>';
+				$html .= '<div class="p_item_name">'.esc_html( stripslashes( $value['c_name'])).'</div>';
 			if ( trim($value['c_about']) != '') {
 			$html .= '<div class="p_about_profile fixed_height">';
 			$html .= wp_kses_post( wpautop( wptexturize( stripslashes( $value['c_about'] ) ) ) );
@@ -772,7 +772,7 @@ class Main {
 					$html .= '<div class="p_content_left">'. wp_kses_post( $img_output ).'</div>';
 				}
 				$html .= '<div class="p_content_right">';
-				$html .= '<h3 class="p_item_name">'.esc_html( stripslashes( $peoples['c_name'])).'</h3>';
+				$html .= '<div class="p_item_name">'.esc_html( stripslashes( $peoples['c_name'])).'</div>';
 			if ( trim($peoples['c_about']) != '') {
 			$html .= '<div class="p_about_profile fixed_height">';
 			$html .= wp_kses_post( wpautop( wptexturize( stripslashes( $peoples['c_about'] ) ) ) );

--- a/people-contact.php
+++ b/people-contact.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Contact Us page - Contact people LITE
 Description: Instantly and easily create a simply stunning Contact Us page on almost any theme. Google location map, People Contact Profiles and a fully featured Contact Us widget. Fully responsive and easy to customize. Ultimate Version upgrade for even more features.
-Version: 3.8.1
+Version: 3.8.2
 Author: a3rev Software
 Author URI: https://a3rev.com/
 Requires at least: 6.0
@@ -41,7 +41,7 @@ if (!defined("PEOPLE_CONTACT_ULTIMATE_URI")) define("PEOPLE_CONTACT_ULTIMATE_URI
 
 define( 'PEOPLE_CONTACT_KEY', 'contact_us_page_contact_people' );
 define( 'PEOPLE_CONTACT_PREFIX', 'people_contact_' );
-define( 'PEOPLE_CONTACT_VERSION', '3.8.1' );
+define( 'PEOPLE_CONTACT_VERSION', '3.8.2' );
 define( 'PEOPLE_CONTACT_G_FONTS', true );
 
 use \A3Rev\ContactPeople\FrameWork;

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: a3rev, nguyencongtuan
 Tags: Contact Us, Contact Us Page, WordPress Contact Us, People Contact, Contact Forms
 Requires at least: 6.0
 Tested up to: 7.0
-Stable tag: 3.8.1
+Stable tag: 3.8.2
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -133,6 +133,10 @@ Want to add a new language to WP Email Template! You can contribute via [transla
 
 
 == Changelog ==
+
+= 3.8.2 - 2026/06/25 =
+* This maintenance release has an SEO improvement.
+* Tweak - Profile name heading changed from an H3 tag to a div element on profile cards to prevent duplicate H3 headings on pages where multiple profiles are displayed, improving page SEO heading hierarchy and accessibility compliance.
 
 = 3.8.1 - 2026/06/23 =
 * This maintenance release has an SEO improvement and security hardening.
@@ -759,6 +763,9 @@ Want to add a new language to WP Email Template! You can contribute via [transla
 
 
 == Upgrade Notice ==
+
+= 3.8.2 =
+* This maintenance release has an SEO improvement.
 
 = 3.8.1 =
 * This maintenance release has an SEO improvement and security hardening.


### PR DESCRIPTION
## Summary

* Tweak - Profile name heading changed from an H3 tag to a `div` element on profile cards to prevent duplicate H3 headings on pages where multiple profiles are displayed, improving page SEO heading hierarchy and accessibility compliance.

## Changes

- `classes/class-people-contact.php` - Replaced `<h3 class="p_item_name">` with `<div class="p_item_name">` in both `create_contact_maps()` and `create_people_contact()` methods
- `people-contact.php` - Version bumped to 3.8.2
- `readme.txt` - Stable tag updated to 3.8.2, new 3.8.2 changelog entry added

## Test plan

- [ ] Verify contact profile cards render correctly on the Contact Us page
- [ ] Confirm profile name is no longer wrapped in an H3 tag (inspect element)
- [ ] Check SEO heading hierarchy is correct when multiple profiles are on one page
- [ ] Test single profile shortcode display

Made with [Cursor](https://cursor.com)